### PR TITLE
Missing get_data in nyul.get_landmarks

### DIFF
--- a/intensity_normalization/normalize/nyul.py
+++ b/intensity_normalization/normalize/nyul.py
@@ -106,7 +106,7 @@ def get_landmarks(img, percs):
     Returns:
         landmarks (np.ndarray): intensity values corresponding to percs in img
     """
-    landmarks = np.percentile(img, percs)
+    landmarks = np.percentile(img.get_data(), percs)
     return landmarks
 
 


### PR DESCRIPTION
Use get_data from Nifti1Image file before computing percentiles