### PR TITLE
reduce docker image size + minor improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,23 @@
 # Use official python runtime as a parent image
-FROM python:3.6-stretch
-MAINTAINER Jacob Reinhold, jacob.reinhold@jhu.edu
+FROM python:3.6-slim-stretch
+LABEL maintainer="Jacob Reinhold, jacob.reinhold@jhu.edu"
 
 # Set the working directory to /app
 WORKDIR /app
 
 # Copy the current directory contents into the container at /app
-ADD . /app
+COPY . .
 
 # 1) Install numpy first since skfuzzy requires it to be pre-installed
 # 2) Install any needed packages specified in requirements.txt
 # 3) Install ANTsPy which currently requires a specific path
 # 4) Install this package into the container
 # 5) Setup matplotlib to not pull in a GUI
-RUN pip install --upgrade pip && \
-    pip install numpy && \
-    pip install --trusted-host pypi.python.org -r requirements.txt && \
-    pip install antspyx && \
+RUN pip install --upgrade --no-cache-dir pip && \
+    pip install --no-cache-dir numpy && \
+    pip install --no-cache-dir --trusted-host pypi.python.org -r requirements.txt && \
+    pip install --no-cache-dir antspyx && \
     python setup.py install && \
     echo "backend: agg" > matplotlibrc
+
+WORKDIR /work


### PR DESCRIPTION
This PR reduces the Docker image size to 1.42 GB from 2.6 GB. These are uncompressed sizes. Most of these savings are from disabling pip's cache directory. This PR also makes some minor improvements to the Dockerfile.

- use python slim docker images
- use `--no-cache-dir` in `pip install` commands
- replace `MAINTAINER` with `LABEL maintainer= ...` because `MAINTAINER` is deprecated
- use `COPY` instead of `ADD`